### PR TITLE
Adds unit tests for SnapViewController

### DIFF
--- a/spec/controllers/attachments_view_controller_spec.rb
+++ b/spec/controllers/attachments_view_controller_spec.rb
@@ -6,10 +6,6 @@ describe AttachmentsView do
 
   tests AttachmentsView
 
-  after do
-    @help_methods.window_cleanup(window, controller)
-  end
-
   describe 'AttachmentsView #init' do
 
     it 'should create seven attr_accessors :attachment_behavior, :square1, :box1, :sq1_attachment_image_view, :attachment_view ' do
@@ -30,8 +26,8 @@ describe AttachmentsView do
   describe 'AttachmentsView #viewDidLoad' do
 
    it 'added four subviews' do
-      controller.self.view.subviews.count.should.equal 4
-    end
+     controller.self.view.subviews.count.should.equal 4
+   end
 
     it 'created an ImageView subview: square1' do
       controller.sq1_attachment_image_view.class.should.equal UIImageView
@@ -41,7 +37,7 @@ describe AttachmentsView do
       controller.square1.subviews.count.should.equal 2
     end
 
-    it 'created an ImageView subview: @box1' do
+    it 'created an ImageView subview box1' do
       controller.box1.class.should.equal UIImageView
     end
 
@@ -74,6 +70,22 @@ describe AttachmentsView do
     it 'creates an observer for DecorationView\'s attached_view object\'s centre method' do
       should.not.raise(NSRangeException) {controller.view.attached_view.removeObserver(controller.view, forKeyPath: 'center') }
       should.raise(NSRangeException) {controller.view.attached_view.removeObserver(controller.view, forKeyPath: 'not_center') }
+    end
+  end
+
+  describe 'AttachmentsView UIPanGestureRecognizer action method #handle_attachment_gesture.' do
+    before do
+    end
+
+    it 'should set the attachment_behavior\'s anchorPoint.' do
+      gesture = controller.view.gestureRecognizers[0]
+      controller.send(:handle_attachment_gesture, gesture)
+      (controller.attachment_behavior.anchorPoint.x == 0.0 && controller.attachment_behavior.anchorPoint.y == 0.0).should.equal true
+    end
+
+    it 'should set the attachment_view\'s center to be equal to the anchorPoint center.' do
+      (controller.attachment_view.center.x == controller.attachment_behavior.anchorPoint.x).should.equal true
+      (controller.attachment_view.center.y == controller.attachment_behavior.anchorPoint.y).should.equal true
     end
   end
 end

--- a/spec/controllers/base_view_controller_spec.rb
+++ b/spec/controllers/base_view_controller_spec.rb
@@ -1,9 +1,5 @@
 describe BaseViewController do
 
-  after do
-    SpecHelper.create_help_methods.window_cleanup(window, controller)
-  end
-
   tests BaseViewController
 
   describe 'BaseViewController #new_box' do

--- a/spec/controllers/collision_view_controller_spec.rb
+++ b/spec/controllers/collision_view_controller_spec.rb
@@ -2,10 +2,6 @@ describe CollisionViewController do
 
   tests CollisionViewController
 
-  after do
-    SpecHelper.create_help_methods.window_cleanup(window, controller)
-  end
-
   describe "CollisionViewController #viewDidLoad" do
     it "adds a box to the subview" do
       controller.view.subviews.count.should.equal 1

--- a/spec/controllers/continuous_and_instantaneous_push_view_controller_spec.rb
+++ b/spec/controllers/continuous_and_instantaneous_push_view_controller_spec.rb
@@ -10,10 +10,6 @@ vcs.each do |vc|
 
     tests vc
 
-    after do
-      @help_methods.window_cleanup(window, controller)
-    end
-
     describe "#{vc.to_s}\'s init" do
 
       it 'should create a square1 and push_behavior attr_accessors' do

--- a/spec/controllers/custom_dynamic_item_view_controller_spec.rb
+++ b/spec/controllers/custom_dynamic_item_view_controller_spec.rb
@@ -6,10 +6,6 @@ describe CustomDynamicItemViewController do
 
   tests CustomDynamicItemViewController
 
-  after do
-    @help_methods.window_cleanup(window, controller)
-  end
-
   it 'should create an attr_accessor button_bounds' do
     @help_methods.do_methods_respond(controller, :button_bounds, :button_bounds=).should.equal 'All Methods responded'
   end

--- a/spec/controllers/examples_table_controller_spec.rb
+++ b/spec/controllers/examples_table_controller_spec.rb
@@ -6,10 +6,6 @@ describe ExamplesTableController do
 
   tests ExamplesTableController
 
-  after do
-    @help_method.window_cleanup(window, controller)
-  end
-
   describe 'ExamplesTableController #viewDidLoad' do
 
     it 'sets the title' do

--- a/spec/controllers/gravity_view_controller_spec.rb
+++ b/spec/controllers/gravity_view_controller_spec.rb
@@ -2,10 +2,6 @@ describe GravityViewController do
 
   tests GravityViewController
 
-  after do
-    SpecHelper.create_help_methods.window_cleanup(window, controller)
-  end
-
   describe 'GravityViewController #viewDidLoad' do
     it 'created an ImageView subview: box' do
       controller.box.class.should.equal UIImageView

--- a/spec/controllers/item_properties_view_controller_spec.rb
+++ b/spec/controllers/item_properties_view_controller_spec.rb
@@ -6,11 +6,6 @@ describe ItemPropertiesViewController do
 
   tests ItemPropertiesViewController
 
-  after do
-    @help_methods.window_cleanup(window, controller)
-  end
-
-
   describe 'ItemPropertiesViewController #init' do
 
     it 'should create four attr_accessors :box_one, :box_two, :box_two_property, :box_one_property' do

--- a/spec/controllers/pendulum_view_controller_spec.rb
+++ b/spec/controllers/pendulum_view_controller_spec.rb
@@ -5,10 +5,6 @@ describe PendulumViewController do
 
   tests PendulumViewController
 
-  after do
-    @help_methods.window_cleanup(window, controller)
-  end
-
   describe 'PendulumViewController #init' do
     it 'should create attr_accessors :attachmentPoint, :pendulumBehavior' do
       @help_methods.do_methods_respond(controller, :attachment_point, :attachment_point=, :pendulum_behavior, :pendulum_behavior=).
@@ -18,12 +14,10 @@ describe PendulumViewController do
 
   describe 'PendulumViewController #viewDidLoad' do
     it 'should assign a UILabel as a controller Subview. ' do
-      controller.view.subviews[1].class.should.equal UILabel
       controller.view.subviews[1].object_id.should.equal controller.instance_variable_get('@label').object_id
     end
 
-    it 'should assign box imageImageView to the second subview of the controller\'s view. ' do
-      controller.view.subviews[2].class.should.equal NSKVONotifying_UIImageView
+    it 'should assign box imageImageView to the third subview of the controller\'s view. ' do
       controller.view.subviews[2].object_id.should.equal controller.box.object_id
     end
 

--- a/spec/controllers/snap_view_controller_spec.rb
+++ b/spec/controllers/snap_view_controller_spec.rb
@@ -1,0 +1,39 @@
+describe SnapViewController do
+
+  before do
+     @help_methods = SpecHelper.create_help_methods
+   end
+
+   tests SnapViewController
+
+  describe 'SnapViewController #init' do
+    it 'should create attr_accessor :snap_behavior' do
+      @help_methods.do_methods_respond(controller, :snap_behavior, :snap_behavior=).
+                                   should.equal 'All Methods responded'
+    end
+  end
+
+  describe 'SnapViewController #viewDidLoad' do
+    it 'should assign a UILabel as the first controller subview.' do
+      controller.view.subviews[0].object_id.should.equal controller.instance_variable_get('@label').object_id
+    end
+
+    it 'should assign box imageImageView as the second subview of the controller\'s view. ' do
+      controller.view.subviews[1].object_id.should.equal controller.box.object_id
+    end
+
+    it "should have a UITapGestureRecognizer that responds to a tap action." do
+      controller.view.gestureRecognizers[0].class.should == UITapGestureRecognizer
+    end
+  end
+
+  describe "SnapViewController's UITapGestureRecognizer gesture recognizer action #handle_tap" do
+    it 'should move the center of the box after taping the view at location 200.0, 200.0 ' do
+      box_center_before_tap = controller.box.center
+      tap(controller.view, at: CGPointMake(200.0, 200.0), :times => 1, :touches => 1)
+      box_center_after_tap = controller.box.center
+      box_center_after_tap.x.should.be > box_center_before_tap.x
+      box_center_after_tap.y.should.be > box_center_before_tap.y
+    end
+  end
+end

--- a/spec/helpers/spec_helpers.rb
+++ b/spec/helpers/spec_helpers.rb
@@ -61,11 +61,4 @@ class SpecHelper
       end
   controller_test_results
   end
-
-
-  def window_cleanup(window, controller)
-    window = nil
-    controller = nil
-  end
-
 end


### PR DESCRIPTION
- Removes window and controller cleanup method as MacBacon does its own
  cleanup of controller and window created by each spec file’s tests
  method.
